### PR TITLE
Fix drush si

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -69,6 +69,7 @@ execute "install-disconnected-empty-db-site" do
   command DRUSH_SI
   only_if DRUPAL_DISCONNECTED
   not_if DB_FULL
+  not_if  "test -f '#{node['deploy-drupal']['sql_load_file']}'", :cwd => DEPLOY_PROJECT_DIR
   notifies :run, "execute[populate-fresh-installation-db]", :immediately
   notifies :run, "execute[drush-cache-clear]", :delayed
   notifies :run, "execute[drush-suppress-http-status-error]", :delayed


### PR DESCRIPTION
Currently crashes with D6 because it hardcodes the install profile "standard", which only works in D7 whereas D7 calls it default. This can be fixed by simply removing the explicit profile argument, and let `drush si` decide.

Also add an extra condition to ensure that `drush si` isn't run if DB dump is provided. In that case the only usefulness of running `drush si` is to populate `settings-priv.php` but this will be soon handled via https://github.com/amirkdv/chef-deploy-drupal/issues/1
